### PR TITLE
Add function to set format type to GPSPublisher.cs

### DIFF
--- a/Scripts/Runtime/GPS/GPSPublisher.cs
+++ b/Scripts/Runtime/GPS/GPSPublisher.cs
@@ -9,8 +9,17 @@ using RosMessageTypes.Nmea;
 [RequireComponent(typeof(FRJ.Sensor.GPS))]
 public class GPSPublisher : MonoBehaviour
 {
+    private enum FORMAT_TYPE
+    {
+        GPRMC,
+        GPGGA,
+        GPGSA,
+        GPVTG
+    }
+
     [SerializeField] private string _topicName = "nmea/sentence";
     [SerializeField] private string _frameId   = "nmea_link";
+    [SerializeField] private FORMAT_TYPE _formatType;
     
     private float _timeElapsed = 0f;
     private float _timeStamp   = 0f;
@@ -57,7 +66,25 @@ public class GPSPublisher : MonoBehaviour
             uint nanosec = (uint)( (this._timeStamp - sec)*1e+9 );
             this._message.header.stamp.sec = sec;
             this._message.header.stamp.nanosec = nanosec;
-            this._message.sentence = this._gps.gpgga;
+
+            switch (_formatType)
+            {
+                case FORMAT_TYPE.GPRMC:
+                    this._message.sentence = this._gps.gprmc;
+                    break;
+                case FORMAT_TYPE.GPGGA:
+                    this._message.sentence = this._gps.gpgga;
+                    break;
+                case FORMAT_TYPE.GPGSA:
+                    this._message.sentence = this._gps.gpgsa;
+                    break;
+                case FORMAT_TYPE.GPVTG:
+                    this._message.sentence = this._gps.gpvtg;
+                    break;
+                default:
+                    this._message.sentence = "";
+                    break;
+            }
 
             this._ros.Send(this._topicName, this._message);
         }


### PR DESCRIPTION
[Field-Robotics-Japan/UnitySensors/PR15](https://github.com/Field-Robotics-Japan/UnitySensors/pull/15)と対応。
新たに追加されたGPS通信フォーマット用の設定項目を、GPSPublisher.csに追加。

![image](https://user-images.githubusercontent.com/37181352/182347765-71198d63-52a3-49a4-8652-d051a8d4fbc8.png)
